### PR TITLE
Support negative score

### DIFF
--- a/HaloEzAPI.Tests/HaloAPIServiceTests/Stats/GetCustomPostGameCarnageReportTests.cs
+++ b/HaloEzAPI.Tests/HaloAPIServiceTests/Stats/GetCustomPostGameCarnageReportTests.cs
@@ -30,5 +30,14 @@ namespace HaloEzAPI.Tests.HaloAPIServiceTests.Stats
             var result = await HaloApiService.GetCustomPostGameCarnageReport(_validGuid);
             Assert.IsTrue(result.PlayerStats.Any(ps => ps.Player.Gamertag.Equals(gamerTag,StringComparison.InvariantCultureIgnoreCase)));
         }
+
+        [Test]
+        [TestCase("fcbd9c03-5602-43cb-97ba-af415137a32b")]
+        public async void ProvideValidMatchId_NegativeScore(string matchId)
+        {
+            var result = await HaloApiService.GetCustomPostGameCarnageReport(new Guid("fcbd9c03-5602-43cb-97ba-af415137a32b"));
+            
+            Assert.AreEqual(-1, result.TeamStats.First().Score);
+        }
     }
 }

--- a/HaloEzAPI/Converter/ScoreConverter.cs
+++ b/HaloEzAPI/Converter/ScoreConverter.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace HaloEzAPI.Converter
+{
+    public class ScoreConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            uint unsignedValue;
+            unchecked
+            {
+                // Have to cast to an int first because value is an Int32
+                unsignedValue = (uint)(int)value;
+            }
+
+            serializer.Serialize(writer, unsignedValue);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            uint unsignedValue = serializer.Deserialize<uint>(reader);
+
+            int signedValue;
+            unchecked
+            {
+                signedValue = (int)unsignedValue;
+            }
+
+            return signedValue;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(int);
+        }
+    }
+}

--- a/HaloEzAPI/Converter/TimeSpanConverter.cs
+++ b/HaloEzAPI/Converter/TimeSpanConverter.cs
@@ -7,7 +7,7 @@ namespace HaloEzAPI.Converter
     /// <summary>
     /// Taken from: http://stackoverflow.com/questions/12633588/parsing-iso-duration-with-json-net
     /// </summary>
-    public class JSONTimeSpanConverter : JsonConverter
+    public class TimeSpanConverter : JsonConverter
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
@@ -16,7 +16,7 @@ namespace HaloEzAPI.Converter
             serializer.Serialize(writer, tsString);
         }
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,JsonSerializer serializer)
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             if (reader.TokenType == JsonToken.Null)
             {

--- a/HaloEzAPI/HaloEzAPI.csproj
+++ b/HaloEzAPI/HaloEzAPI.csproj
@@ -87,7 +87,8 @@
     <Compile Include="Abstraction\Interfaces\IRangeDamageDealt.cs" />
     <Compile Include="Abstraction\Interfaces\IWinLoss.cs" />
     <Compile Include="Caching\CacheManager.cs" />
-    <Compile Include="Converter\JSONTimeSpanConverter.cs" />
+    <Compile Include="Converter\TimeSpanConverter.cs" />
+    <Compile Include="Converter\ScoreConverter.cs" />
     <Compile Include="Endpoints.cs" />
     <Compile Include="HaloAPIService.cs" />
     <Compile Include="IHaloAPIService.cs" />

--- a/HaloEzAPI/Model/Response/Stats/CampaignPlayerStat.cs
+++ b/HaloEzAPI/Model/Response/Stats/CampaignPlayerStat.cs
@@ -5,7 +5,7 @@ namespace HaloEzAPI.Model.Response.Stats
 {
     public class CampaignPlayerStat : PlayerMatchBreakdown
     {
-        public uint BiggestKillScore { get; set; }
+        public int BiggestKillScore { get; set; }
         public FlexibleStats FlexibleStats { get; set; }
         [JsonConverter(typeof(ScoreConverter))]
         public int Score { get; set; }

--- a/HaloEzAPI/Model/Response/Stats/CampaignPlayerStat.cs
+++ b/HaloEzAPI/Model/Response/Stats/CampaignPlayerStat.cs
@@ -1,10 +1,14 @@
+using HaloEzAPI.Converter;
+using Newtonsoft.Json;
+
 namespace HaloEzAPI.Model.Response.Stats
 {
     public class CampaignPlayerStat : PlayerMatchBreakdown
     {
         public uint BiggestKillScore { get; set; }
         public FlexibleStats FlexibleStats { get; set; }
-        public uint Score { get; set; }
+        [JsonConverter(typeof(ScoreConverter))]
+        public int Score { get; set; }
         public Player Player { get; set; }
         public int TeamId { get; set; }
         public int Rank { get; set; }

--- a/HaloEzAPI/Model/Response/Stats/MatchDetails.cs
+++ b/HaloEzAPI/Model/Response/Stats/MatchDetails.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using HaloEzAPI.Converter;
 using Newtonsoft.Json;
 
 namespace HaloEzAPI.Model.Response.Stats
@@ -10,9 +11,9 @@ namespace HaloEzAPI.Model.Response.Stats
         public Guid GameBaseVariantId { get; set; }
         public Variant GameVariant { get; set; }
         public bool IsTeamGame { get; set; }
-        [JsonConverter(typeof(Converter.JSONTimeSpanConverter))]
+        [JsonConverter(typeof(TimeSpanConverter))]
         public TimeSpan MatchDuration { get; set; }
-        [JsonConverter(typeof(Converter.JSONTimeSpanConverter))]
+        [JsonConverter(typeof(TimeSpanConverter))]
         public TimeSpan TotalDuration { get; set; }
         public Guid MapVariantId { get; set; }
         public Guid GameVariantId { get; set; }

--- a/HaloEzAPI/Model/Response/Stats/PlayerMatchBreakdown.cs
+++ b/HaloEzAPI/Model/Response/Stats/PlayerMatchBreakdown.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using HaloEzAPI.Abstraction.Interfaces;
+using HaloEzAPI.Converter;
 using Newtonsoft.Json;
 
 namespace HaloEzAPI.Model.Response.Stats
@@ -31,7 +32,7 @@ namespace HaloEzAPI.Model.Response.Stats
         public int TotalGamesWon { get; set; }
         public int TotalGamesLost { get; set; }
         public int TotalGamesTied { get; set; }
-        [JsonConverter(typeof(Converter.JSONTimeSpanConverter))]
+        [JsonConverter(typeof(TimeSpanConverter))]
         public TimeSpan TotalTimePlayed { get; set; }
         public int TotalGrenadeKills { get; set; }
         public IEnumerable<MedalAward> MedalAwards { get; set; }

--- a/HaloEzAPI/Model/Response/Stats/RoundStat.cs
+++ b/HaloEzAPI/Model/Response/Stats/RoundStat.cs
@@ -1,9 +1,13 @@
+using HaloEzAPI.Converter;
+using Newtonsoft.Json;
+
 namespace HaloEzAPI.Model.Response.Stats
 {
     public class RoundStat
     {
         public int RoundNumber { get; set; }
         public int Rank { get; set; }
-        public uint Score { get; set; }
+        [JsonConverter(typeof(ScoreConverter))]
+        public int Score { get; set; }
     }
 }

--- a/HaloEzAPI/Model/Response/Stats/StatTimelapse.cs
+++ b/HaloEzAPI/Model/Response/Stats/StatTimelapse.cs
@@ -1,4 +1,5 @@
 using System;
+using HaloEzAPI.Converter;
 using Newtonsoft.Json;
 
 namespace HaloEzAPI.Model.Response.Stats
@@ -7,7 +8,7 @@ namespace HaloEzAPI.Model.Response.Stats
     {
         public Guid Id { get; set; }
         [JsonIgnore]
-        [JsonConverter(typeof(Converter.JSONTimeSpanConverter))]
+        [JsonConverter(typeof(TimeSpanConverter))]
         public TimeSpan Timelapse { get; set; }
     }
 }

--- a/HaloEzAPI/Model/Response/Stats/Team.cs
+++ b/HaloEzAPI/Model/Response/Stats/Team.cs
@@ -1,4 +1,7 @@
-﻿namespace HaloEzAPI.Model.Response.Stats
+﻿using HaloEzAPI.Converter;
+using Newtonsoft.Json;
+
+namespace HaloEzAPI.Model.Response.Stats
 {
     public class Team
     {
@@ -17,7 +20,8 @@
         /// Strongholds = number of points,
         /// Warzone = number of points
         /// </summary>
-        public uint Score { get; set; }
+        [JsonConverter(typeof(ScoreConverter))]
+        public int Score { get; set; }
 
         //The team's rank at the end of the match.
         public int Rank { get; set; }

--- a/HaloEzAPI/Model/Response/Stats/TeamStat.cs
+++ b/HaloEzAPI/Model/Response/Stats/TeamStat.cs
@@ -1,11 +1,15 @@
+using System;
 using System.Collections.Generic;
+using HaloEzAPI.Converter;
+using Newtonsoft.Json;
 
 namespace HaloEzAPI.Model.Response.Stats
 {
     public class TeamStat
     {
         public int TeamId { get; set; }
-        public uint Score { get; set; }
+        [JsonConverter(typeof(ScoreConverter))]
+        public int Score { get; set; }
         public int Rank { get; set; }
         public IEnumerable<RoundStat> RoundStats { get; set; } 
     }

--- a/HaloEzAPI/Model/Response/Stats/WeaponKillDetail.cs
+++ b/HaloEzAPI/Model/Response/Stats/WeaponKillDetail.cs
@@ -1,4 +1,5 @@
 using System;
+using HaloEzAPI.Converter;
 using Newtonsoft.Json;
 
 namespace HaloEzAPI.Model.Response.Stats
@@ -11,7 +12,7 @@ namespace HaloEzAPI.Model.Response.Stats
         public double TotalDamageDealt { get; set; }
         public int TotalShotsFired { get; set; }
         public int TotalShotsLanded { get; set; }
-        [JsonConverter(typeof(Converter.JSONTimeSpanConverter))]
+        [JsonConverter(typeof(TimeSpanConverter))]
         public TimeSpan TotalPossessionTime { get; set; }
     }
 }


### PR DESCRIPTION
This is a continuation of glitch100/Halo-API#2.

Scores can go negative. In the test custom game, when the team scores -1, the API returns the max value of a 32-bit unsigned int. This adds a converter that will cast the value from unsigned to signed when coming in and back from signed to unsigned when going out.  This is the only place that I've seen this signed/unsigned mismatch.  As such, I've reverted `BiggestKillScore` to an int.
