### PR TITLE
Fix typo in PercentToNextTier

### DIFF
--- a/HaloEzAPI/Model/Response/Stats/CSR.cs
+++ b/HaloEzAPI/Model/Response/Stats/CSR.cs
@@ -5,7 +5,7 @@ namespace HaloEzAPI.Model.Response.Stats
         public int Tier { get; set; }
         public int DesignationId { get; set; }
         public int Csr { get; set; }
-        public int PercentTotNextTier { get; set; }
+        public int PercentToNextTier { get; set; }
         public int? Rank { get; set; }
     }
 }


### PR DESCRIPTION
This was preventing proper parsing of this property.
